### PR TITLE
Allow interaction with details tag

### DIFF
--- a/main/screens/chapterReader.jsx
+++ b/main/screens/chapterReader.jsx
@@ -416,6 +416,7 @@ const ChapterReader = ({
 
     // Handle tap events and send to RN
     document.addEventListener('click', (e) => {
+      if (e.target.closest('summary')) return;
       if (!['A', 'BUTTON', 'INPUT'].includes(e.target.tagName)) {
         e.preventDefault();
         if (window.ReactNativeWebView) {


### PR DESCRIPTION
It is used on AO3 for spoilers.

<table>
  <tr>
    <td><img width="720" height="1280" alt="Screenshot_20260603-130105_CO3" src="https://github.com/user-attachments/assets/955633be-fe73-4a1f-a6f9-3c74326311f9" /></td>
    <td><img width="720" height="1280" alt="Screenshot_20260603-130120_CO3" src="https://github.com/user-attachments/assets/eef0fa11-f535-4e48-9cfe-5bd6e4a8aa20" /></td>
  </tr>
</table>

Example tag taken from [AO3](https://archiveofourown.org/works/79079871/chapters/218860411)
```html
<details>
    <summary><strong>Click to reveal image (spoiler)</strong></summary>
    <p><br><img src="https://files.catbox.moe/vkgnfn.png" alt="spoiler image"></p>
</details>
```